### PR TITLE
Replace frunk with low-overhead coproduct library

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ license = "MIT OR Apache-2.0"
 
 [dependencies]
 effing-macros = { path = "effing-macros" }
-coproduct = "0.2"
+coproduct = "0.3"
 
 # for sync-and-async example
 futures = { version = "0.3.23", optional = true, default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ license = "MIT OR Apache-2.0"
 
 [dependencies]
 effing-macros = { path = "effing-macros" }
-frunk = { version = "0.4.0", default-features = false }
+coproduct = "0.2"
 
 # for sync-and-async example
 futures = { version = "0.3.23", optional = true, default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ license = "MIT OR Apache-2.0"
 
 [dependencies]
 effing-macros = { path = "effing-macros" }
-coproduct = "0.3"
+coproduct = { version = "0.4", features = ["type_inequality_hack"] }
 
 # for sync-and-async example
 futures = { version = "0.3.23", optional = true, default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ license = "MIT OR Apache-2.0"
 
 [dependencies]
 effing-macros = { path = "effing-macros" }
-coproduct = { version = "0.4", features = ["type_inequality_hack"] }
+coproduct = { version = "0.4.1", features = ["type_inequality_hack"] }
 
 # for sync-and-async example
 futures = { version = "0.3.23", optional = true, default-features = false }

--- a/effing-macros/src/lib.rs
+++ b/effing-macros/src/lib.rs
@@ -17,9 +17,8 @@ fn quote_do(e: &Expr) -> Expr {
     parse_quote! {
         {
             use ::core::ops::{Generator, GeneratorState};
-            use ::effing_mad::coproduct::Coproduct;
             let mut gen = #e;
-            let mut injection = Coproduct::inject(::effing_mad::injection::Begin);
+            let mut injection = ::effing_mad::coproduct::inject(::effing_mad::injection::Begin);
             loop {
                 // safety: same as in `handle_group`
                 let pinned = unsafe { ::core::pin::Pin::new_unchecked(&mut gen) };
@@ -61,7 +60,7 @@ impl syn::fold::Fold for Effectful {
                     {
                         let effect = { #expr };
                         let marker = ::effing_mad::macro_impl::mark(&effect);
-                        let injs = yield ::effing_mad::coproduct::Coproduct::inject(effect);
+                        let injs = yield ::effing_mad::coproduct::inject(effect);
                         ::effing_mad::macro_impl::get_inj(injs, marker).unwrap()
                     }
                 }
@@ -385,7 +384,7 @@ impl<T: ToTokens> syn::fold::Fold for FixControlFlow<T> {
                 };
                 parse_quote! {
                     return ::core::ops::ControlFlow::Continue(
-                        ::effing_mad::coproduct::Coproduct::inject(#inj)
+                        ::effing_mad::coproduct::inject(#inj)
                     )
                 }
             }
@@ -495,7 +494,7 @@ pub fn handler(input: TokenStream) -> TokenStream {
                     Ok(#new_pat) => {
                         let __effing_inj = #body;
                         #[allow(unreachable_code)]
-                        ::effing_mad::coproduct::Coproduct::inject(
+                        ::effing_mad::coproduct::inject(
                             ::effing_mad::injection::Tagged::<_, #eff_ty #generics>::new(
                                 __effing_inj
                             )

--- a/examples/transform.rs
+++ b/examples/transform.rs
@@ -3,7 +3,6 @@
 
 use core::ops::ControlFlow;
 
-use coproduct::IdType;
 use effing_mad::{effectful, handle, run, transform, Effect};
 
 fn main() {
@@ -19,19 +18,16 @@ fn main() {
     run(handled);
 }
 
-#[derive(IdType)]
 struct Print(String);
 impl Effect for Print {
     type Injection = ();
 }
 
-#[derive(IdType)]
 struct Log(String, i32);
 impl Effect for Log {
     type Injection = ();
 }
 
-#[derive(IdType)]
 struct Lunchtime;
 impl Effect for Lunchtime {
     type Injection = ();

--- a/examples/transform.rs
+++ b/examples/transform.rs
@@ -3,16 +3,15 @@
 
 use core::ops::ControlFlow;
 
-use effing_mad::{effectful, handle, run, transform0, transform1, Effect};
+use coproduct::IdType;
+use effing_mad::{effectful, handle, run, transform, Effect};
 
 fn main() {
     let work = take_over_the_world();
     // Log, Lunchtime -> Print, Lunchtime
-    // Introducing 1 new effect (Print) so must use transform1
-    let transformed = transform1(work, print_log);
+    let transformed = transform(work, print_log);
     // Print, Lunchtime -> Print
-    // Not introducing new effects so must use transform0
-    let transformed = transform0(transformed, print_lunchtime);
+    let transformed = transform(transformed, print_lunchtime);
     let handled = handle(transformed, |Print(message)| {
         println!("{message}");
         ControlFlow::Continue(())
@@ -20,16 +19,19 @@ fn main() {
     run(handled);
 }
 
+#[derive(IdType)]
 struct Print(String);
 impl Effect for Print {
     type Injection = ();
 }
 
+#[derive(IdType)]
 struct Log(String, i32);
 impl Effect for Log {
     type Injection = ();
 }
 
+#[derive(IdType)]
 struct Lunchtime;
 impl Effect for Lunchtime {
     type Injection = ();

--- a/src/injection.rs
+++ b/src/injection.rs
@@ -2,7 +2,7 @@
 
 use core::marker::PhantomData;
 
-use frunk::{coproduct::CNil, Coproduct};
+use coproduct::{Coproduct, EmptyUnion, IndexedDrop, Union};
 
 use crate::Effect;
 
@@ -37,10 +37,17 @@ pub trait EffectList {
     type Injections;
 }
 
-impl EffectList for CNil {
-    type Injections = Coproduct<Begin, CNil>;
+impl<U: EffectList + IndexedDrop> EffectList for Coproduct<U>
+where
+    U::Injections: IndexedDrop,
+{
+    type Injections = Coproduct<U::Injections>;
 }
 
-impl<E: Effect, Es: EffectList> EffectList for Coproduct<E, Es> {
-    type Injections = Coproduct<Tagged<E::Injection, E>, Es::Injections>;
+impl EffectList for EmptyUnion {
+    type Injections = Union<Begin, EmptyUnion>;
+}
+
+impl<E: Effect, Es: EffectList> EffectList for Union<E, Es> {
+    type Injections = Union<Tagged<E::Injection, E>, Es::Injections>;
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -31,7 +31,7 @@ where
     F: Generator<Coproduct<Union<Begin, EmptyUnion>>, Yield = Coproduct<EmptyUnion>, Return = R>,
 {
     let pinned = core::pin::pin!(f);
-    match pinned.resume(Coproduct::inject(Begin)) {
+    match pinned.resume(coproduct::inject(Begin)) {
         GeneratorState::Yielded(absurd) => absurd.ex_falso(),
         GeneratorState::Complete(ret) => ret,
     }
@@ -106,7 +106,7 @@ where
     handle_group(g, move |effs: Coproduct!(Handled)| match effs.take_head() {
         Ok(eff) => match handler(eff) {
             ControlFlow::Continue(inj) => {
-                ControlFlow::Continue(Coproduct::inject(Tagged::new(inj)))
+                ControlFlow::Continue(coproduct::inject(Tagged::new(inj)))
             }
             ControlFlow::Break(ret) => ControlFlow::Break(ret),
         },
@@ -183,7 +183,7 @@ where
     G: Generator<Coproduct!(Tagged<Eff::Injection, Eff>, Begin), Yield = Coproduct!(Eff)>,
     Fut: Future<Output = ControlFlow<G::Return, Eff::Injection>>,
 {
-    let mut injs = Coproduct::inject(Begin);
+    let mut injs = coproduct::inject(Begin);
     loop {
         // safety: see handle_group() - remember that futures are pinned in the same way as
         // generators
@@ -196,7 +196,7 @@ where
                 };
                 match handler(eff).await {
                     ControlFlow::Continue(new_injs) => {
-                        injs = Coproduct::inject(Tagged::new(new_injs))
+                        injs = coproduct::inject(Tagged::new(new_injs))
                     }
                     ControlFlow::Break(ret) => return ret,
                 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,7 +7,7 @@ pub mod injection;
 pub mod macro_impl;
 
 pub use coproduct;
-use coproduct::{Coproduct, Count, Embed, EmptyUnion, IndexedDrop, Merge, Split, Union};
+use coproduct::{Coproduct, Count, Embed, EmptyUnion, Merge, Split, Union};
 use core::{
     future::Future,
     ops::{ControlFlow, Generator, GeneratorState},

--- a/src/macro_impl.rs
+++ b/src/macro_impl.rs
@@ -1,16 +1,9 @@
 //! Implementation details of the macros exported by `effing_mad`.
 
+use coproduct::{self, Coproduct, EmptyUnion, IndexedDrop, Union};
 use core::marker::PhantomData;
 
-use frunk::{
-    coproduct::{CNil, CoprodUninjector},
-    Coproduct,
-};
-
-use crate::{
-    injection::{EffectList, Tagged},
-    Effect, EffectGroup,
-};
+use crate::{injection::Tagged, Effect, EffectGroup};
 
 #[must_use]
 pub fn mark<T>(_: &T) -> PhantomData<T> {
@@ -20,20 +13,27 @@ pub fn mark<T>(_: &T) -> PhantomData<T> {
 pub fn get_inj<E, Injs, Index>(injs: Injs, _marker: PhantomData<E>) -> Option<E::Injection>
 where
     E: Effect,
-    Injs: CoprodUninjector<Tagged<E::Injection, E>, Index>,
+    Injs: coproduct::At<Index, Tagged<E::Injection, E>>,
 {
     injs.uninject().ok().map(Tagged::untag)
 }
 
 pub trait FlattenEffects {
-    type Out: EffectList;
+    type Out;
 }
 
-impl<G, Tail> FlattenEffects for Coproduct<G, Tail>
+impl<T: IndexedDrop, O> FlattenEffects for Coproduct<T>
+where
+    T: FlattenEffects<Out = O>,
+    O: IndexedDrop,
+{
+    type Out = Coproduct<<T as FlattenEffects>::Out>;
+}
+
+impl<G, Tail> FlattenEffects for Union<G, Tail>
 where
     G: EffectGroup,
     <G as EffectGroup>::Effects: Prepend<Tail>,
-    <<G as EffectGroup>::Effects as Prepend<Tail>>::Out: EffectList,
 {
     type Out = <<G as EffectGroup>::Effects as Prepend<Tail>>::Out;
 }
@@ -42,10 +42,10 @@ pub trait Prepend<Tail> {
     type Out;
 }
 
-impl<Tail> Prepend<Tail> for CNil {
+impl<Tail> Prepend<Tail> for EmptyUnion {
     type Out = Tail;
 }
 
-impl<Head, Tail1: Prepend<Tail2>, Tail2> Prepend<Tail2> for Coproduct<Head, Tail1> {
-    type Out = Coproduct<Head, Tail1::Out>;
+impl<Head, Tail1: Prepend<Tail2>, Tail2> Prepend<Tail2> for Union<Head, Tail1> {
+    type Out = Union<Head, Tail1::Out>;
 }


### PR DESCRIPTION
I want to try an architecture that uses effect groups with lots of variants but the coproduct offered by frunk uses ridiculous amounts of memory when it has many variants. I am also not convinced that rustc can optimize the methods very well.

Thus I wrote a library for coproducts that are just a tag and a union. With that representation, all operations can be written as tag manipulations; the union's type changes but the in-memory representation does not.

Meanwhile, this library progressed in a nice direction, so I'd rather contribute to this than continue making my own.

In the [discussion I had during the development of the library](https://github.com/lloydmeta/frunk/pull/199), I heard about your desire for a minimal common superset. I believe it can be done. It requires assigning numbers to effects at compile time, similar to what [this crate](https://crates.io/crates/unique-type-id) does. That gives a way to check if two effects are equal. The rest has been done already: frunk's CoproductSubsetter filters out a list of types from a coproduct, just need to make that list the list of effects that are present in both.