### PR TITLE
Replace all mentions of "generator" with "coroutine"

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ I wanted to see what would happen.
 
 ## how cool is it?
 effing-mad is cool. Rad, even. Check out all these cool things it has:
-* unstable compiler features (generators, generator_trait)
+* unstable compiler features (coroutines, coroutine_trait)
 * a function with 22 type arguments
 * `#![no_std]`
 * scary category theory words (coproduct! 👻)
@@ -70,10 +70,10 @@ On the other hand, I do understand algebraic effects, and therefore they are goo
 far more easily and in my opinion are more intuitive. Download effing-mad today!
 
 ## more facts - to do with rust this time
-effing-mad uses generators. The implementation of it was made far easier by the lang team already
-needing functions that can be suspended and resumed, because that caused them to invent generators.
+effing-mad uses coroutines. The implementation of it was made far easier by the lang team already
+needing functions that can be suspended and resumed, because that caused them to invent coroutines.
 Even though they were made for the compiler to be able to compile async fns, they're way more
 general than async fns are.
 
-Generators are used by the compiler, but directly using them has not been stabilised yet because no
+Coroutines are used by the compiler, but directly using them has not been stabilised yet because no
 one really needs it to be. That's why you need to use a nightly compiler to use effing-mad.

--- a/effing-macros/src/lib.rs
+++ b/effing-macros/src/lib.rs
@@ -19,7 +19,7 @@ fn quote_do(e: &Expr) -> Expr {
             let mut injection = Coproduct::inject(::effing_mad::injection::Begin);
             loop {
                 // interesting hack to trick the borrow checker
-                // allows cloneable generators
+                // allows cloneable coroutines
                 let res = {
                     // safety: same as in `handle_group`
                     let pinned = unsafe { ::core::pin::Pin::new_unchecked(&mut gen) };
@@ -107,7 +107,7 @@ impl syn::visit_mut::VisitMut for Effectful {
 /// It is possible to create effectful functions whose computations can be cloned. This requires
 /// marking the function as `#[effectful::cloneable]` after the `#[effectful(...)]` invocation,
 /// the function to have only `Clone` and `Unpin` locals, and the function to never hold a
-/// reference to a local across a yield point. In other words, the underlying generator must be
+/// reference to a local across a yield point. In other words, the underlying coroutine must be
 /// `Clone` and `Unpin`.
 #[proc_macro_attribute]
 pub fn effectful(args: TokenStream, item: TokenStream) -> TokenStream {

--- a/src/injection.rs
+++ b/src/injection.rs
@@ -8,7 +8,7 @@ use crate::Effect;
 
 /// Before an effectful computation has started, there is no injection to pass in, because no
 /// effects have been run yet. However, due to the signature of
-/// [`Generator::resume`](core::ops::Generator::resume), it is necessary to pass one in anyway.
+/// [`Coroutine::resume`](core::ops::Coroutine::resume), it is necessary to pass one in anyway.
 /// This type is used as a first injection for all effectful computations.
 #[derive(Clone, Copy)]
 pub struct Begin;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -70,7 +70,7 @@ pub enum Never {}
 
 /// Run an effectful computation that has no effects.
 ///
-/// Effectful computations are generators, but if they have no effects, it is guaranteed that they
+/// Effectful computations are coroutines, but if they have no effects, it is guaranteed that they
 /// will never yield. Therefore they can be run by resuming them once. This function does that.
 pub fn run<F, R>(mut f: F) -> R
 where
@@ -247,7 +247,7 @@ where
     let mut injs = Coproduct::inject(Begin);
     loop {
         // safety: see handle_group() - remember that futures are pinned in the same way as
-        // generators
+        // coroutines
         let pinned = unsafe { Pin::new_unchecked(&mut g) };
         match pinned.resume(injs) {
             CoroutineState::Yielded(effs) => {
@@ -287,7 +287,7 @@ where
     let mut injs = Is::inject(Begin);
     loop {
         // safety: see handle_group() - remember that futures are pinned in the same way as
-        // generators
+        // coroutines
         let pinned = unsafe { Pin::new_unchecked(&mut g) };
         match pinned.resume(injs) {
             CoroutineState::Yielded(effs) => match handler(effs).await {


### PR DESCRIPTION
Also fixes the compilation of the crate when the `alloc` feature flag is enabled.

(Personally) I would recommend adding a CI workflow to prevent this from happening in the future, maybe using [dtolnay/rust-toolchain](https://github.com/dtolnay/rust-toolchain)?